### PR TITLE
feat: introduce lisk sepolia

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -65,6 +65,12 @@ const config = {
       url: `https://sepolia.infura.io/v3/${process.env.INFURA_KEY}`,
       tags: ["moduleMastercopy"],
     },
+    "lisk-sepolia": {
+      ...sharedNetworkConfig,
+      chainId: 4202,
+      url: "https://rpc.sepolia-api.lisk.com",
+      gasPrice: 1000000000,
+    },
   },
 
   namedAccounts: {
@@ -77,7 +83,23 @@ const config = {
     currency: "USD",
   },
   etherscan: {
-    apiKey: process.env.ETHERSCAN_API_KEY,
+    apiKey: {
+      mainnet: process.env.ETHERSCAN_API_KEY,
+      sepolia: process.env.ETHERSCAN_API_KEY,
+      gnosis: process.env.GNOSISSCAN_API_KEY,
+      matic: process.env.POLYGONSCAN_API_KEY,
+      "lisk-sepolia": process.env.ETHERSCAN_API_KEY,
+    },
+    customChains: [
+      {
+        network: "lisk-sepolia",
+        chainId: 4202,
+        urls: {
+          apiURL: "https://sepolia-blockscout.lisk.com/api",
+          browserURL: "https://sepolia-blockscout.lisk.com",
+        },
+      },
+    ],
   },
 }
 


### PR DESCRIPTION
## **Description:**

This PR adds support for the **Lisk Sepolia** testnet in Hardhat configuration. The newly introduced network allows deploying and verifying smart contracts on Lisk's Sepolia blockchain.

### Changes:
- Added `lisk-sepolia` network configuration to `hardhat.config.ts`.
- Included `lisk-sepolia` under the `etherscan.apiKey` configuration using a placeholder key.
- Extended `customChains` configuration to support contract verification for Lisk Sepolia.

### Deployment and Verification:
The following contracts were successfully deployed on **Lisk Sepolia**:

- 🚀 ERC20Votes@1.0.0: Successfully verified at https://sepolia-blockscout.lisk.com/address/0x752c61de75ADA0F8a33e048d2F773f51172f033e
- 🚀 ERC20Votes@1.1.0: Successfully verified at https://sepolia-blockscout.lisk.com/address/0x9a73aE387eb97EF59765bd13ECF1E37f28515b70
- 🚀 ERC721Votes@1.0.0: Successfully verified at https://sepolia-blockscout.lisk.com/address/0xeFf38b2eBB95ACBA09761246045743f40e762568
- 🚀 ERC721Votes@1.1.0: Successfully verified at https://sepolia-blockscout.lisk.com/address/0x45d755348601c312eFF29f65E2DeB596F97331b6
- 🚀 OZGovernorModule@1.0.0: Successfully verified at https://sepolia-blockscout.lisk.com/address/0xe28c39FAC73cce2B33C4C003049e2F3AE43f77d5
- 🚀 OZGovernorModule@1.1.0: Successfully verified at https://sepolia-blockscout.lisk.com/address/0x0E5da824AbBC578aafCA16f6A3583E2A916183Ff
- 🚀 MultisendEncoder@1.0.0: Successfully verified at https://sepolia-blockscout.lisk.com/address/0xb67EDe523171325345780fA3016b7F5221293df0
- 🚀 MultisendEncoder@1.1.0: Successfully verified at https://sepolia-blockscout.lisk.com/address/0x574C22059b3e65C3467241901a175EC2a05cAF8E


### References:
- Official Lisk documentation: [Deploying Smart Contracts with Hardhat](https://docs.lisk.com/building-on-lisk/deploying-smart-contract/with-Hardhat)
